### PR TITLE
Ensure numerical prerelease identifiers are compared numerically

### DIFF
--- a/PoshSemanticVersion/PoshSemanticVersion.psm1
+++ b/PoshSemanticVersion/PoshSemanticVersion.psm1
@@ -531,7 +531,15 @@ function New-SemanticVersion {
                     }
 
                     for ([int] $i = 0; $i -lt $shortestArray; $i++) {
-                        if ($PreRelease[$i] -notmatch '^[0-9]+$' -and ($VersionPreRelease[$i] -match '^[0-9]+$')) {
+                        if ($PreRelease[$i] -match '^[0-9]+$' -and ($VersionPreRelease[$i] -match '^[0-9]+$')) {
+                            if (([int] $PreRelease[$i]) -gt ([int] $VersionPreRelease[$i])) {
+                                $returnValue = 1
+                            }
+                            elseif (([int] $PreRelease[$i]) -lt ([int] $VersionPreRelease[$i])) {
+                                $returnValue = -1
+                            }
+                        }
+                        elseif ($PreRelease[$i] -notmatch '^[0-9]+$' -and ($VersionPreRelease[$i] -match '^[0-9]+$')) {
                             $returnValue = 1
                         }
                         elseif ($PreRelease[$i] -match '^[0-9]+$' -and ($VersionPreRelease[$i] -notmatch '^[0-9]+$')) {
@@ -650,7 +658,15 @@ function New-SemanticVersion {
                     }
 
                     for ([int] $i = 0; $i -lt $shortestArray; $i++) {
-                        if ($PreRelease[$i] -notmatch '^[0-9]+$' -and ($VersionPreRelease[$i] -match '^[0-9]+$')) {
+                        if ($PreRelease[$i] -match '^[0-9]+$' -and ($VersionPreRelease[$i] -match '^[0-9]+$')) {
+                            if (([int] $PreRelease[$i]) -gt ([int] $VersionPreRelease[$i])) {
+                                $returnValue = 1
+                            }
+                            elseif (([int] $PreRelease[$i]) -lt ([int] $VersionPreRelease[$i])) {
+                                $returnValue = -1
+                            }
+                        }
+                        elseif ($PreRelease[$i] -notmatch '^[0-9]+$' -and ($VersionPreRelease[$i] -match '^[0-9]+$')) {
                             $returnValue = 1
                         }
                         elseif ($PreRelease[$i] -match '^[0-9]+$' -and ($VersionPreRelease[$i] -notmatch '^[0-9]+$')) {

--- a/tests/PoshSemanticVersion.tests.ps1
+++ b/tests/PoshSemanticVersion.tests.ps1
@@ -271,6 +271,13 @@ InModuleScope $moduleName {
 
                 $compareOutput.Precedence | Should Be '>'
 
+                $semver1 = New-SemanticVersion '1.2.3-11'
+                $semver2 = New-SemanticVersion '1.2.3-2'
+
+                $compareOutput = Compare-SemanticVersion -ReferenceVersion $semver1 -DifferenceVersion $semver2
+
+                $compareOutput.Precedence | Should Be '>'
+
                 $semver1 = New-SemanticVersion '1.2.3-a'
                 $semver2 = New-SemanticVersion '1.2.3-0'
 
@@ -319,6 +326,13 @@ InModuleScope $moduleName {
 
                 $semver1 = New-SemanticVersion '1.2.3-0'
                 $semver2 = New-SemanticVersion '1.2.3-1'
+
+                $compareOutput = Compare-SemanticVersion -ReferenceVersion $semver1 -DifferenceVersion $semver2
+
+                $compareOutput.Precedence | Should Be '<'
+
+                $semver1 = New-SemanticVersion '1.2.3-2'
+                $semver2 = New-SemanticVersion '1.2.3-11'
 
                 $compareOutput = Compare-SemanticVersion -ReferenceVersion $semver1 -DifferenceVersion $semver2
 
@@ -609,6 +623,11 @@ InModuleScope $moduleName {
 
                 $semver1.CompareTo($semver2) | Should BeGreaterThan 0
 
+                $semver1 = New-SemanticVersion -String '1.0.0-11'
+                $semver2 = New-SemanticVersion -String '1.0.0-2'
+
+                $semver1.CompareTo($semver2) | Should BeGreaterThan 0
+
                 $semver1 = New-SemanticVersion -String '1.0.0-a'
                 $semver2 = New-SemanticVersion -String '1.0.0-0'
 
@@ -655,6 +674,11 @@ InModuleScope $moduleName {
 
                 $semver1 = New-SemanticVersion -String '1.0.0-0'
                 $semver2 = New-SemanticVersion -String '1.0.0-1'
+
+                $semver1.CompareTo($semver2) | Should BeLessThan 0
+
+                $semver1 = New-SemanticVersion -String '1.0.0-2'
+                $semver2 = New-SemanticVersion -String '1.0.0-11'
 
                 $semver1.CompareTo($semver2) | Should BeLessThan 0
 


### PR DESCRIPTION
First, let me say thank you so much for making PoshSemanticVersion and making it available. This has been super useful for a project I'm currently working on.

This PR updates the comparison logic for prerelease identifiers such that if the current pair of identifiers being compared are both numerical, then the identifiers are converted to integers and compared numerically. Currently they are compared lexically, resulting in a version like 1.0.0-beta.2 compared as having a higher precedence than a version like 1.0.0-beta.11. Example output from the current version of PoshSemanticVersion:

    PS> Compare-SemanticVersion -ReferenceVersion 1.0.0-beta.2 -DifferenceVersion 1.0.0-beta.11
    
    ReferenceVersion Precedence DifferenceVersion IsCompatible
    ---------------- ---------- ----------------- ------------
    1.0.0-beta.2     >          1.0.0-beta.11            False

From paragraph 11 on SemVer.org, the relevant example showing what ought to be the correct precedence ordering is given as follows (emphasis mine): 1.0.0-alpha < ... < **1.0.0-beta.2 < 1.0.0-beta.11** < ... < 1.0.0.

I updated both the CompareTo and CompareVersions functions as they seemed to both handle version comparisons. A set of unit tests using similar version strings as the examples above have also been added to confirm the desired precedence ordering.

If this PR looks good and you end up accepting it, do you know what the timeline would be for a new version of PoshSemanticVersion being pushed out to the PS Gallery? Thanks so much for your work!